### PR TITLE
Fix to split the tip by number of people

### DIFF
--- a/SettingsViewController.swift
+++ b/SettingsViewController.swift
@@ -12,18 +12,56 @@ class SettingsViewController: UIViewController {
     
     
     @IBOutlet weak var defaultTipPercentageControl: UISegmentedControl!
-
-    @IBOutlet weak var numberOfPeopleField: UILabel!
+    @IBOutlet weak var numOfPeopleField: UILabel!
+    @IBOutlet weak var changePeopleNumControl: UIStepper!
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
+        loadSettingScreenWithValues()
+    }
+    
+    /**
+     * loadSettingScreenWithValues will load the values into the Settings part based on what user
+     * had previously set
+    **/
+    func loadSettingScreenWithValues() {
+        
+        let defaults = UserDefaults.standard
+        
+        //Setting the default tip percentage in Settings Screen as set by user
+        let selectedDefaultTipPosition = defaults.integer(forKey: "defaultTipPercentageKey")
+        print("Default Values set by user:")
+        print(selectedDefaultTipPosition)
+        defaultTipPercentageControl.selectedSegmentIndex = selectedDefaultTipPosition
+        
+        //Setting the default number of people in Setting Screen as set by user
+        let selectedNumberOfPeople = defaults.double(forKey: "numOfPeopleKey")
+        print(selectedNumberOfPeople)
+        numOfPeopleField.text = String(format: "%.0f", selectedNumberOfPeople)
+        changePeopleNumControl.value = selectedNumberOfPeople
+        print(numOfPeopleField.text)
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
+    }
+    
+    @IBAction func setNumberOfPeople(_ sender: UIStepper) {
+        
+        //Extracting the number of people from stepper
+        let numOfPeopleFromStepper = changePeopleNumControl.value
+        
+        //Assigning the number of people to the text field
+        numOfPeopleField.text = String(format: "%.0f", numOfPeopleFromStepper)
+        
+        //Set number of people as default to use in Main screen
+        let defaults = UserDefaults.standard
+        defaults.set(numOfPeopleFromStepper, forKey: "numOfPeopleKey")
+        defaults.synchronize()
+
     }
     
 
@@ -50,4 +88,6 @@ class SettingsViewController: UIViewController {
         print(selectedDefaultTipPosition)
         
     }
+    
+    
 }

--- a/TipCalculator/Base.lproj/Main.storyboard
+++ b/TipCalculator/Base.lproj/Main.storyboard
@@ -28,34 +28,20 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Tip" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FRI-or-MVt">
-                                <frame key="frameInset" minX="16" minY="136" width="32" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Tip per Person" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FRI-or-MVt">
+                                <frame key="frameInset" minX="16" minY="136" width="112" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="1" green="0.68047091719999997" blue="0.01737822537" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Total" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7U4-d4-VMQ">
-                                <frame key="frameInset" minX="16" minY="184" width="42" height="21"/>
+                                <frame key="frameInset" minX="16" minY="256" width="42" height="64"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="1" green="0.68047091719999997" blue="0.01737822537" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <segmentedControl opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" segmentControlStyle="plain" selectedSegmentIndex="0" id="yvl-KX-NdK">
-                                <frame key="frameInset" minX="16" minY="239" width="343" height="29"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" red="1" green="0.85595624299999995" blue="0.1513445829" alpha="1" colorSpace="calibratedRGB"/>
-                                <segments>
-                                    <segment title="18%"/>
-                                    <segment title="20%"/>
-                                    <segment title="25%"/>
-                                </segments>
-                                <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                <connections>
-                                    <action selector="calculateTip:" destination="BYZ-38-t0r" eventType="valueChanged" id="cSl-ZF-2nG"/>
-                                </connections>
-                            </segmentedControl>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="$0.0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2AH-zM-5ff">
                                 <frame key="frameInset" minX="186" minY="136" width="173" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -64,14 +50,16 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="$0.0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="sDg-3e-grt">
-                                <frame key="frameInset" minX="186" minY="184" width="173" height="21"/>
+                                <frame key="frameInset" minX="186" minY="278" width="173" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="1" green="0.85595624299999995" blue="0.1513445829" alpha="1" colorSpace="calibratedRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.9836989116" green="1" blue="0.97928807449999999" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="highlightedColor" white="0.70054773339999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="highlightedColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <size key="shadowOffset" width="0.0" height="0.0"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Bill" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="kHh-Sz-2hi">
-                                <frame key="frameInset" minX="16" minY="88" width="32" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Bill Amount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="kHh-Sz-2hi">
+                                <frame key="frameInset" minX="16" minY="88" width="87" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="1" green="0.68047091719999997" blue="0.01737822537" alpha="1" colorSpace="calibratedRGB"/>
@@ -87,6 +75,28 @@
                                     <action selector="calculateTip:" destination="BYZ-38-t0r" eventType="editingChanged" id="G4Y-WC-GeC"/>
                                 </connections>
                             </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Xif-RG-k1g">
+                                <frame key="frameInset" minX="16" minY="247" width="343" height="8"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="1" green="0.82282199320000005" blue="0.23274536730000001" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" segmentControlStyle="plain" selectedSegmentIndex="0" id="yvl-KX-NdK">
+                                <frame key="frameInset" minX="65" minY="176" width="239" height="29"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="1" green="0.85595624299999995" blue="0.1513445829" alpha="1" colorSpace="calibratedRGB"/>
+                                <segments>
+                                    <segment title="18%"/>
+                                    <segment title="20%"/>
+                                    <segment title="25%"/>
+                                </segments>
+                                <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                <connections>
+                                    <action selector="calculateTip:" destination="BYZ-38-t0r" eventType="valueChanged" id="cSl-ZF-2nG"/>
+                                </connections>
+                            </segmentedControl>
                         </subviews>
                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                         <color key="tintColor" red="1" green="0.85595624299999995" blue="0.1513445829" alpha="1" colorSpace="calibratedRGB"/>
@@ -117,7 +127,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="392" y="-469"/>
+            <point key="canvasLocation" x="391.5" y="-469.5"/>
         </scene>
         <!--Settings-->
         <scene sceneID="r1V-lT-1Fx">
@@ -128,7 +138,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" segmentControlStyle="plain" selectedSegmentIndex="0" id="8d9-h9-P1Z">
-                                <frame key="frameInset" minX="28" minY="178" width="319" height="29"/>
+                                <frame key="frameInset" minX="16" minY="178" width="335" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" red="1" green="0.85595624295936734" blue="0.15134458290766439" alpha="1" colorSpace="calibratedRGB"/>
                                 <segments>
@@ -136,37 +146,40 @@
                                     <segment title="20%"/>
                                     <segment title="25%"/>
                                 </segments>
-                                <color key="tintColor" white="0.70054773338909804" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" white="0.70054773339999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <action selector="setDefaultTipPercentage:" destination="71n-lj-XQT" eventType="valueChanged" id="e9v-1Z-9IJ"/>
                                 </connections>
                             </segmentedControl>
-                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" contentHorizontalAlignment="fill" contentVerticalAlignment="center" maximumValue="10" id="mWg-pG-gUJ" colorLabel="IBBuiltInLabel-Yellow">
+                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minimumValue="1" maximumValue="10" id="mWg-pG-gUJ" colorLabel="IBBuiltInLabel-Yellow">
                                 <frame key="frameInset" minX="257" minY="255" width="94" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.5"/>
-                                <color key="tintColor" red="1" green="0.85595624299999995" blue="0.1513445829" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="1" green="0.85595624299999995" blue="0.1513445829" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <connections>
+                                    <action selector="setNumberOfPeople:" destination="71n-lj-XQT" eventType="valueChanged" id="5Nh-dy-KGA"/>
+                                </connections>
                             </stepper>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zv2-Ne-T3U">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="1" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Zv2-Ne-T3U">
                                 <frame key="frameInset" minX="184" minY="255" width="57" height="29"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" red="1" green="0.85595624299999995" blue="0.1513445829" alpha="1" colorSpace="calibratedRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.94668322801589966" green="0.93270397186279297" blue="0.026382196694612503" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="highlightedColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="highlightedColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Default Tip Percentage" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="U5O-gM-ugk">
-                                <frame key="frameInset" minX="28" minY="137" width="176" height="21"/>
+                                <frame key="frameInset" minX="16" minY="133" width="225" height="25"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                 <color key="textColor" red="1" green="0.82282199320000005" blue="0.23274536730000001" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                                 <color key="shadowColor" red="1" green="0.85595624299999995" blue="0.1513445829" alpha="1" colorSpace="calibratedRGB"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Number of People" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ZHv-lk-3uG">
-                                <frame key="frameInset" minX="28" minY="255" width="307" height="21"/>
+                                <frame key="frameInset" minX="16" minY="254" width="160" height="31"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                 <color key="textColor" red="1" green="0.82282199320000005" blue="0.23274536730000001" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="highlightedColor" red="0.9836989116" green="1" blue="0.97928807449999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <color key="shadowColor" cocoaTouchSystemColor="lightTextColor"/>
@@ -178,8 +191,9 @@
                     </view>
                     <navigationItem key="navigationItem" title="Settings" prompt="" id="aIP-nC-f2r"/>
                     <connections>
+                        <outlet property="changePeopleNumControl" destination="mWg-pG-gUJ" id="tOf-v2-kAY"/>
                         <outlet property="defaultTipPercentageControl" destination="8d9-h9-P1Z" id="qBc-Rs-ffh"/>
-                        <outlet property="numberOfPeopleField" destination="Zv2-Ne-T3U" id="50z-k1-UUK"/>
+                        <outlet property="numOfPeopleField" destination="Zv2-Ne-T3U" id="Qaj-go-OLQ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xzm-YL-rqZ" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/TipCalculator/ViewController.swift
+++ b/TipCalculator/ViewController.swift
@@ -36,9 +36,10 @@ class ViewController: UIViewController {
     **/
     @IBAction func calculateTip(_ sender: AnyObject) {
         
-        recalculateTip()
+        let selectedNumberOfPeople = 1
+        recalculateTip(numberOfPeople: selectedNumberOfPeople)
     }
-    
+
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -52,24 +53,44 @@ class ViewController: UIViewController {
         //Setting the default tip amount in Tippy main screen
         tipControl.selectedSegmentIndex = selectedDefaultTipPosition
         
-        //Recalculate the tip based on new tip selection from settings
-        recalculateTip()
+        //Check if number of people is > 1
+        let selectedNumberOfPeople = defaults.integer(forKey: "numOfPeopleKey")
         
+        //Recalculate the tip based on new tip selection from settings
+        recalculateTip(numberOfPeople: selectedNumberOfPeople)
     }
     
-    func recalculateTip() {
+    func recalculateTip(numberOfPeople: Int) {
         let tipPercentages = [0.18, 0.20, 0.25]
         let billAmount = Double(billField.text!) ?? 0
         let tipAmount = billAmount * tipPercentages[tipControl.selectedSegmentIndex]
-        let totalAmount = billAmount + tipAmount
         
-        tipLabel.text = String(format: "$%.2f", tipAmount)
+        //Checking if there is more than 1 person, to split the tip amount, based on data from Settings and seeting the tip value
+        if (numberOfPeople > 1) {
+            let tipPerPerson = (tipAmount/Double(numberOfPeople))
+             tipLabel.text = String(format: "$%.2f", tipPerPerson)
+            
+        } else {
+            tipLabel.text = String(format: "$%.2f", tipAmount)
+        }
+        
+        //Setting the total amount based on the tip amount and the bill amount
+        let totalAmount = billAmount + tipAmount
         totalLabel.text = String(format: "$%.2f", totalAmount)
+
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         print("view did appear")
+        
+        // Animation Block
+        self.tipLabel.alpha = 0
+        self.totalLabel.alpha = 0
+        UIView.animate(withDuration: 0.6, animations: {
+            self.tipLabel.alpha = 1
+            self.totalLabel.alpha = 1
+        })
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -81,6 +102,6 @@ class ViewController: UIViewController {
         super.viewDidDisappear(animated)
         print("view did disappear")
     }
-
+    
 }
 


### PR DESCRIPTION
This Pull Request contains code to set the number of people who will be splitting the tip in the Settings page, and then displaying the tip that needs to be paid by each person from the group. 

In addition, it also contains:
- Retaining of default split percentage and number of people in the Settings page
- Animation on the home page, bringing the user's attention to the tip per person and the total
- Some refactoring