### PR TITLE
Making bill amount the first responder

### DIFF
--- a/TipCalculator/ViewController.swift
+++ b/TipCalculator/ViewController.swift
@@ -18,6 +18,9 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
+        
+        //Making the bill amount field the first responder with keyboard on
+        billField.becomeFirstResponder()
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
This PR for issue #4 ensures that the Bill Amount field acts as the first responder and the keyboard is open as the app launches.